### PR TITLE
Simplify Ruff version management in CI

### DIFF
--- a/home-assistant-{{ cookiecutter.project_name }}/.github/workflows/lint.yaml
+++ b/home-assistant-{{ cookiecutter.project_name }}/.github/workflows/lint.yaml
@@ -22,7 +22,6 @@ jobs:
         run: |
           npx --package=renovate@38 -- renovate-config-validator .github/renovate.json5
 
-      - uses: astral-sh/ruff-action@v3.4
       - uses: codespell-project/actions-codespell@v2.0
         with:
           check_hidden: false

--- a/home-assistant-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/home-assistant-{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -9,22 +9,22 @@ repos:
         args:
           - --allow-multiple-documents
       - id: check-added-large-files
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
-    hooks:
-      - id: ruff-check
-        types_or:
-          - python
-          - pyi
-        args:
-          - --fix
-          - --exit-non-zero-on-fix
-      - id: ruff-format
-        types_or:
-          - python
-          - pyi
   - repo: local
     hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: uv run --no-project ruff check --fix --exit-non-zero-on-fix
+        language: system
+        types_or:
+          - python
+          - pyi
+      - id: ruff-format
+        name: ruff format
+        entry: uv run --no-project ruff format
+        language: system
+        types_or:
+          - python
+          - pyi
       - id: ty
         name: ty check
         entry: uv run --no-project ty check . --ignore unresolved-import


### PR DESCRIPTION
Remove standalone astral-sh/ruff-action step from the lint workflow template. Downstream CI will run Ruff from requirements_dev.txt, establishing a single source of truth for the Ruff version.

Closes #9